### PR TITLE
Fixes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <groupId>org.orbisgis</groupId>
     <artifactId>MApUCE_tools</artifactId>
     <name>MApUCE_tools</name>
-    <version>1.0.0</version>
+    <version>1.0.1-SNAPSHOT</version>
     <packaging>bundle</packaging>
     <parent>
         <groupId>org.orbisgis</groupId>

--- a/src/main/java/org/orbisgis/mapuce/WpsScriptsPackage.java
+++ b/src/main/java/org/orbisgis/mapuce/WpsScriptsPackage.java
@@ -221,7 +221,7 @@ public class WpsScriptsPackage {
         final File tempFile = new File(tempFolder.getAbsolutePath(), new File(scriptUrl.getFile()).getName());
         if(!tempFile.exists()) {
             try{
-                if(tempFile.createNewFile()){
+                if(!tempFile.createNewFile()){
                     LOGGER.error("Unable to create the script file.");
                     return;
                 }
@@ -271,7 +271,7 @@ public class WpsScriptsPackage {
         final File tempFile = new File(tempFolder.getAbsolutePath(), iconName);
         if(!tempFile.exists()) {
             try{
-                if(tempFile.createNewFile()){
+                if(!tempFile.createNewFile()){
                     LOGGER.error("Unable to create the icon file.");
                     return null;
                 }


### PR DESCRIPTION
Switch the version to 1.0.1-SNAPSHOT.
Fixes the the copy of the resources. We the plugin is loaded, the resources are copied into the .OrbisGIS folder.
