### PR TITLE
Fix a bug on USR id

### DIFF
--- a/src/main/resources/org/orbisgis/mapuce/scripts/randomforest_typo.R
+++ b/src/main/resources/org/orbisgis/mapuce/scripts/randomforest_typo.R
@@ -27,7 +27,7 @@ tab_typo_bati=cbind.data.frame(data_predict[,1],typologie)
 dbWriteTable(con, "TMP_TYPO_BUILDINGS_MAPUCE", tab_typo_bati, append=TRUE, row.names=FALSE)
 
 ### Compute floor percent
-pct_bati=data_predict$i_floor/data_predict$u_floor*100
+pct_bati=ifelse(data_predict$u_floor!=0, data_predict$i_floor/data_predict$u_floor*100,0)
 
 ### Compute % of typologies by USR
 typo_USR=tapply(pct_bati,list(data_predict$pk_usr,typologie),sum)


### PR DESCRIPTION
Fix a possible zero when the PK USR for a building doesn't refer to the good one in the USR table.